### PR TITLE
HEIC to JPEG conversion

### DIFF
--- a/src/components/photo_input.tsx
+++ b/src/components/photo_input.tsx
@@ -92,8 +92,10 @@ const PhotoInput: FC<PhotoInputProps> = ({children, label, metadata, photo, upse
             style={{display: 'none'}}
             type="file"
           /> */}
+        
+          {/*  modifying to accept *.heic and *.jpeg files - Test Photo meta data module #45 */} 
           <input
-            accept="image/jpeg"
+            accept="image/jpeg, image/heic"
             onChange={handleFileInputChange}
             ref={hiddenPhotoUploadInputRef}
             style={{display: 'none'}}

--- a/src/components/photo_input_wrapper.tsx
+++ b/src/components/photo_input_wrapper.tsx
@@ -1,5 +1,7 @@
 import ImageBlobReduce from 'image-blob-reduce'
 import React, {FC} from 'react'
+import heicConvert from 'heic-convert'
+//import heic2jpg from 'heic-jpg'
 
 import {StoreContext} from './store'
 import PhotoInput from './photo_input'
@@ -29,15 +31,54 @@ const PhotoInputWrapper: FC<PhotoInputWrapperProps> = ({children, id, label}) =>
     <StoreContext.Consumer>
       {({attachments, upsertAttachment}) => {
 
-        const upsertPhoto = (file: Blob) => {
+        const upsertPhoto = (img_file: Blob) => {
+          
+
+          // Modification for Test Photo meta data module #45  - Start */ 
+          if (img_file.type == 'image/heic') 
+          {
+             /* heic2any(
+              { blob: img_file, toType: "image/jpeg", quality: 0.5, // cuts the quality and size by half
+              }).then (jpeg_blob => 
+                {
+                 //console.log(jpeg_blob)
+                  
+                 const blob = new Blob([jpeg_blob as BlobPart], {
+                  type: 'image/jpeg',
+                });
+                 console.log(blob)
+                 upsertAttachment(blob, id)
+                 console.log("hei2any input", img_file)
+                 console.log("hei2any output", jpeg_blob)
+                });*/
+
+                img_file.arrayBuffer().then (arrayBuffer => {
+              
+
+                  console.log("img_file arrayBuffer", arrayBuffer)
+                  const outputBuffer = heicConvert({buffer: arrayBuffer, format: 'JPEG' }).then (outputBuffer =>
+                    {
+                      const blob2 = new Blob([outputBuffer], {type: 'image/jpeg'});
+                      //upsertAttachment(blob, id)
+                      console.log("heicConvert input", img_file)
+                      console.log("heicConvert output", blob2)
+                    })
+  
+                });
+               
+             
+          }      
+          else
+          {
           // Reduce the image size as needed
           ImageBlobReduce()
-          .toBlob(file, {max: MAX_IMAGE_DIM})
+          .toBlob(img_file, {max: MAX_IMAGE_DIM})
           .then(blob => {
             upsertAttachment(blob, id)
           })
+          }
         }
-
+      
         return (
           <PhotoInput children={children} label={label}
             metadata={(attachments[id]?.metadata as unknown) as PhotoMetadata}

--- a/src/utilities/photo_utils.tsx
+++ b/src/utilities/photo_utils.tsx
@@ -45,6 +45,8 @@ export async function getPhotoMetadata(photo: Blob): Promise<Attachment["metadat
         },
         timestamp: DateTimeOriginal || null
       }
+      // Temp - remove later
+      console.log(fullMetaData)
       resolve(metadata)
 
     })


### PR DESCRIPTION
heic2any js and heic-convert js libraries usage 

I am adding a heic-convert js to convert heic to jpeg while uploading photos with *.heic format.  I have tried with heic2any js as well, it works fine but unable to retrieve the geotagging. 

I get this error while starting the app when using heic-convert js . Please check below and let me know your suggestions

Module not found: Error: Can't resolve 'stream' in '/Users/eswa830/Library/CloudStorage/OneDrive-PNNL/Documents/GitHub/Remote-QA-Web-App/node_modules/pngjs/lib'
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
        - install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "stream": false }