### PR TITLE
added st address suffix to document / filename

### DIFF
--- a/src/components/print_section.tsx
+++ b/src/components/print_section.tsx
@@ -8,6 +8,7 @@ import ReactToPrint, { useReactToPrint } from 'react-to-print'
 interface PrintSectionProps {
   children: ReactNode,
   label: string
+  filename_suffix: string
 }
 
 /**
@@ -16,18 +17,22 @@ interface PrintSectionProps {
  * @param children Content for printing 
  * @param label Label for the print button
  */
-const PrintSection: FC<PrintSectionProps> = ({children, label}) => {
+const PrintSection: FC<PrintSectionProps> = ({children, label, filename_suffix}) => {
   const printContainerId = useId();
   return (
     <>
-      <Button onClick={event => print({
+      <Button onClick={event => {
+        let title = 'BASC QA Tool'
+        if (filename_suffix) {title += ' - ' + filename_suffix}
+        document.title = title
+        print({
           maxWidth: 2000,
           printable: printContainerId,
           type: 'html', 
           targetStyles: ["*"],
           css: '/print.css',
           documentTitle: 'DOE - Quality Installation Report',
-        })} 
+        })}} 
         variant="primary">
         {label}
       </Button>

--- a/src/templates/doe_workflow_hpwh.mdx
+++ b/src/templates/doe_workflow_hpwh.mdx
@@ -217,7 +217,7 @@
 
   </Tab>
   <Tab eventKey="report" style={{paddingTop:"1rem"}} title="Report">
-    <PrintSection label="Print Report">
+    <PrintSection label="Print Report" filename_suffix={props.data.location?.street_address}>
     ---
     # Heat Pump Water Heater Quality Installation Report
 


### PR DESCRIPTION
Some feedback from Edward Louie was that when working on multiple projects, it can be hard to organize reports since the tool prints everything to the same filename. 

Unfortunately print-js doesn't allow one to specify a filename, so I added this hack to update the document title of the site to include the street address.