### PR TITLE
Move metadata_ initialization logic to putNewDoc()

### DIFF
--- a/src/components/jobs_view.tsx
+++ b/src/components/jobs_view.tsx
@@ -84,7 +84,6 @@ const JobList: React.FC<JobListProps> = ({ dbName }) => {
    }    */
 
     const sortByEditTime = (jobsList: any[]) => {
-        console.log('jobsList:', jobsList)
         const sortedJobsByEditTime = jobsList.sort((a, b) => {
             if (
                 a.metadata_.last_modified_at.toString() <
@@ -129,15 +128,11 @@ const JobList: React.FC<JobListProps> = ({ dbName }) => {
 
     const handleAddJob = async (input: string) => {
         // adding a new job here
-        const name = input
+        const docName = input
         if (name !== null) {
-            const date = new Date()
             await putNewDoc(
                 db,
-                name,
-                date,
-                dbName,
-                templatesConfig[dbName].title,
+                docName,
             )
         }
         // Refresh the job list after adding the new job

--- a/src/components/jobs_view.tsx
+++ b/src/components/jobs_view.tsx
@@ -37,8 +37,7 @@ const JobList: React.FC<JobListProps> = ({ dbName }) => {
         {
             validator: (input: string) => {
                 // Restrict the character set to [a-zA-Z0-9-_#:>]
-                const regex =
-                    /^(?!.*\s\s)[a-zA-Z0-9, \-]{1,64}$/
+                const regex = /^(?!.*\s\s)[a-zA-Z0-9, \-]{1,64}$/
                 return regex.test(input)
             },
             errorMsg:
@@ -130,10 +129,7 @@ const JobList: React.FC<JobListProps> = ({ dbName }) => {
         // adding a new job here
         const docName = input
         if (name !== null) {
-            await putNewDoc(
-                db,
-                docName,
-            )
+            await putNewDoc(db, docName)
         }
         // Refresh the job list after adding the new job
         await retrieveJobs()
@@ -146,7 +142,8 @@ const JobList: React.FC<JobListProps> = ({ dbName }) => {
                 const doc = await db.get(jobId)
                 await db.remove(doc) // Remove the existing document
                 doc._id = newName // Set the new name as the ID
-                if (doc.metadata_?.project_name) doc.metadata_.project_name = input
+                if (doc.metadata_?.project_name)
+                    doc.metadata_.project_name = input
                 await db.putIfNotExists(doc)
             }
 

--- a/src/components/number_input.tsx
+++ b/src/components/number_input.tsx
@@ -4,7 +4,6 @@ import FloatingLabel from 'react-bootstrap/FloatingLabel'
 import Form from 'react-bootstrap/Form'
 import InputGroup from 'react-bootstrap/InputGroup'
 
-
 interface NumberInputProps {
     id: string
     label: string
@@ -93,6 +92,3 @@ const NumberInput: FC<NumberInputProps> = ({
 }
 
 export default NumberInput
-
-
-

--- a/src/components/store.tsx
+++ b/src/components/store.tsx
@@ -75,8 +75,6 @@ export const StoreProvider: FC<StoreProviderProps> = ({
      * @param dbDoc The full object representation of the changed document from the database
      */
     async function processDBDocChange(db: PouchDB.Database, dbDoc: any) {
-        console.log('processDBDocChange2')
-        console.log('dbDoc:', dbDoc)
         revisionRef.current = dbDoc._rev
 
         // Set doc state
@@ -97,7 +95,6 @@ export const StoreProvider: FC<StoreProviderProps> = ({
         // Update the attachments state as needed
         // Note: dbDoc will not have a _attachments field if the document has no attachments
         if (db && dbDoc.hasOwnProperty('_attachments')) {
-            console.log('dbDoc has _attachments')
             // Collect all the new or modified attachments
             const dbDocAttachments = dbDoc._attachments
             const attachmentsMetadata = dbDoc.metadata_.attachments
@@ -113,7 +110,6 @@ export const StoreProvider: FC<StoreProviderProps> = ({
                     (!attachments.hasOwnProperty(attachmentId) ||
                         attachments[attachmentId].digest !== digest)
                 ) {
-                    console.log('New attachment')
                     const blobOrBuffer = await db.getAttachment(
                         docId,
                         attachmentId,
@@ -143,7 +139,6 @@ export const StoreProvider: FC<StoreProviderProps> = ({
                 }
             }
             if (!isEmpty(newAttachments)) {
-                console.log('newAttachments:', newAttachments)
                 // Update the attachments state
                 // Note: We update all new attachments at once to avoid a race condition with state update
                 setAttachments({ ...attachments, ...newAttachments })
@@ -172,8 +167,7 @@ export const StoreProvider: FC<StoreProviderProps> = ({
             try {
                 // It looks like the type def for putIfNotExists does not match its implementation
                 // TODO: Check this over carefully
-                const date = new Date()
-                const result = (await putNewDoc(db, docId, date)) as unknown
+                const result = (await putNewDoc(db, docId)) as unknown
                 revisionRef.current = (result as PouchDB.Core.Response).rev
             } catch (err) {
                 console.error('DB initialization error:', err)
@@ -196,15 +190,11 @@ export const StoreProvider: FC<StoreProviderProps> = ({
                     since: 'now',
                 })
                 .on('change', function (change) {
-                    console.log('Database changed')
-                    console.log('_rev:', change.doc?._rev)
-                    console.log('current:', revisionRef.current)
                     if (
                         change.doc != null &&
                         change.doc._rev !== revisionRef.current
                     ) {
                         // The change must have originated from outside this component, so update component state
-                        console.log('processing DB change')
                         processDBDocChange(db, change.doc)
                     }
                     // else: the change originated from this component, so ignore it

--- a/src/components/string_input.tsx
+++ b/src/components/string_input.tsx
@@ -83,5 +83,3 @@ const StringInput: FC<StringInputProps> = ({
 }
 
 export default StringInput
-
-

--- a/src/utilities/database_utils.tsx
+++ b/src/utilities/database_utils.tsx
@@ -1,4 +1,4 @@
-import templatesConfig from "../templates/templates_config"
+import templatesConfig from '../templates/templates_config'
 
 /**
  * Adds a new document to the PouchDB database with the provided name and date.
@@ -15,7 +15,7 @@ export async function putNewDoc(
     // TODO: Handle the error case better
     const dbInfo = await promisifiedDBInfo(db)
     if (!dbInfo) {
-        throw new Error("Database info should never be null")
+        throw new Error('Database info should never be null')
     }
     // The workflow name is the database name
     const workflow_name = dbInfo.db_name
@@ -41,13 +41,16 @@ export async function putNewDoc(
  * @param {PouchDB.Database<{}>} db - The PouchDB database instance.
  * @returns A Promise to the database's info object
  */
-function promisifiedDBInfo(db: PouchDB.Database<{}>): Promise<PouchDB.Core.DatabaseInfo|null> {
-    return new Promise((res, rej) => db.info(
-        (err, info) => {
+function promisifiedDBInfo(
+    db: PouchDB.Database<{}>,
+): Promise<PouchDB.Core.DatabaseInfo | null> {
+    return new Promise((res, rej) =>
+        db.info((err, info) => {
             if (err) {
-                rej(err);
+                rej(err)
             } else {
-                res(info);
+                res(info)
             }
-    }))
+        }),
+    )
 }

--- a/src/utilities/database_utils.tsx
+++ b/src/utilities/database_utils.tsx
@@ -1,28 +1,53 @@
+import templatesConfig from "../templates/templates_config"
+
 /**
  * Adds a new document to the PouchDB database with the provided name and date.
  * @param {PouchDB.Database<{}>} db - The PouchDB database instance.
  * @param {string} name - The name of the document to be added.
- * @param {Date} date - The date of creation for the document.
- * @returns {Promise<void>} - A Promise that resolves when the document is successfully added.
+ * @returns A Promise that resolves to the new document if one was added.
  */
-
 export async function putNewDoc(
     db: PouchDB.Database<{}>,
-    name: string,
-    date: Date,
-    dbName: string,
-    workflow_title: string,
-): Promise<void> {
-    db.info((err, info) => console.log('db.info:', info))
-    void await db.putIfNotExists({
-        _id: name,
+    docName: string,
+): Promise<unknown> {
+    // Get the current date
+    const now = new Date()
+    // TODO: Handle the error case better
+    const dbInfo = await promisifiedDBInfo(db)
+    if (!dbInfo) {
+        throw new Error("Database info should never be null")
+    }
+    // The workflow name is the database name
+    const workflow_name = dbInfo.db_name
+    // Get the corresponding workflow title from templates_config
+    const workflow_title = templatesConfig[workflow_name].title
+    // Store the new document if it does not exist
+    return db.putIfNotExists({
+        _id: docName,
         metadata_: {
-            created_at: date,
-            last_modified_at: date,
+            created_at: now,
+            last_modified_at: now,
             attachments: {},
-            workflow_name: dbName,
-            workflow_title: workflow_title,
-            project_name: name,
+            workflow_name,
+            workflow_title,
+            project_name: docName,
         },
     })
+}
+
+/**
+ * This converts the info method of a PouchDB database instance, that requires a callback, to a function that
+ * returns a promise to the info object.
+ * @param {PouchDB.Database<{}>} db - The PouchDB database instance.
+ * @returns A Promise to the database's info object
+ */
+function promisifiedDBInfo(db: PouchDB.Database<{}>): Promise<PouchDB.Core.DatabaseInfo|null> {
+    return new Promise((res, rej) => db.info(
+        (err, info) => {
+            if (err) {
+                rej(err);
+            } else {
+                res(info);
+            }
+    }))
 }


### PR DESCRIPTION
## Resolves Issue
https://github.com/pnnl/Quality-Install-Tool/issues/141

## Changes
- The values for created_at, last_modified_at, workflow_name, and workflow_title are now determined in putNewDoc() instead of by the callers.
- Cleaned out a number of console.log()s.
- putNewDoc() now returns a promise to the new document that was created. This fixes a bug in Store.

## Notes
- This should be merged into 134-jobsview-issues, which should then be merged into main.