### PR TITLE
148: Adds async await linting rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,10 @@
         "typescript"
     ],
     "rules": {
-        "prettier/prettier": "error"
+        "prettier/prettier": "error",
+        "require-await": "error",
+        "no-return-await": "error",
+        "no-await-in-loop": "error"
     },
     "parser": "@babel/eslint-parser"
 }


### PR DESCRIPTION
-These linting rules in combo with typescript should prevent async functions from not being handled as async due to user error 
-Tested this by removing certain await statements that are known to break components such as the job view and the linter caught the error
