### PR TITLE
Ch store fixes

### DIFF
--- a/src/components/store.tsx
+++ b/src/components/store.tsx
@@ -66,8 +66,6 @@ export const StoreProvider: FC<StoreProviderProps> = ({
     const [db, setDB] = useState<PouchDB.Database>()
     // The doc state could be anything that is JSON-compatible
     const [doc, setDoc] = useState<Objectish>({})
-    const [data, setData] = useState<JSONValue>({})
-    const [metadata, setMetaData] = useState<Metadata | undefined>(undefined)
 
     /**
      * Updates component state based on a database document change
@@ -84,13 +82,6 @@ export const StoreProvider: FC<StoreProviderProps> = ({
         delete newDoc._rev
 
         setDoc(newDoc)
-        if (db && Boolean(dbDoc.hasOwnProperty('data_'))) {
-            setData(dbDoc.data_)
-        }
-
-        if (db && dbDoc.hasOwnProperty('metadata_')) {
-            setMetaData(dbDoc.metadata_)
-        }
 
         // Update the attachments state as needed
         // Note: dbDoc will not have a _attachments field if the document has no attachments
@@ -334,8 +325,8 @@ export const StoreProvider: FC<StoreProviderProps> = ({
         <StoreContext.Provider
             value={{
                 attachments,
-                data,
-                metadata,
+                data: doc.data_,
+                metadata: doc.metadata_,
                 upsertAttachment,
                 upsertData,
                 upsertDoc,

--- a/src/components/store.tsx
+++ b/src/components/store.tsx
@@ -36,7 +36,6 @@ export const StoreContext = React.createContext({
     metadata: {} satisfies Metadata | undefined,
     upsertAttachment: ((blob: Blob, id: any) => {}) as UpsertAttachment,
     upsertData: ((pathStr: string, data: any) => {}) as UpsertData,
-    upsertDoc: ((pathStr: string, data: any) => {}) as UpsertDoc,
 })
 
 interface StoreProviderProps {
@@ -327,7 +326,6 @@ export const StoreProvider: FC<StoreProviderProps> = ({
                 metadata: doc.metadata_,
                 upsertAttachment,
                 upsertData,
-                upsertDoc,
             }}
         >
             {children}

--- a/src/components/store.tsx
+++ b/src/components/store.tsx
@@ -20,7 +20,9 @@ PouchDB.plugin(PouchDBUpsert)
 
 type UpsertAttachment = (blob: Blob, id: string) => void
 
-type UpsertData = (pathStr: string, data: any) => void
+type UpsertData = (pathStr: string, value: any) => void
+
+type UpsertMetadata = (pathStr: string, value: any) => void
 
 type UpsertDoc = (pathStr: string, data: any) => void
 
@@ -36,6 +38,7 @@ export const StoreContext = React.createContext({
     metadata: {} satisfies Metadata | undefined,
     upsertAttachment: ((blob: Blob, id: any) => {}) as UpsertAttachment,
     upsertData: ((pathStr: string, data: any) => {}) as UpsertData,
+    upsertMetadata: ((pathStr: string, data: any) => {}) as UpsertMetadata,
 })
 
 interface StoreProviderProps {
@@ -248,19 +251,35 @@ export const StoreProvider: FC<StoreProviderProps> = ({
     }
 
     /**
-     * Updates (or inserts) data into the data_ state by invoking updatedDoc function
+     * Updates (or inserts) data into the data_ property of the doc state by invoking updatedDoc function
      *
      * @remarks
      * This function is typically passed to an input wrapper component via the StoreContext.Provider value
      * This function calls updateDoc, with the path to "data_" in dbDoc.
      *
      * @param pathStr A string path such as "foo.bar[2].biz" that represents a path into the doc state
-     * @param data The data that is to be updated/inserted at the path location in the data state
+     * @param value The value that is to be updated/inserted
      */
-    const upsertData: UpsertData = (pathStr, data) => {
+    const upsertData: UpsertData = (pathStr, value) => {
         pathStr = 'data_.' + pathStr
-        upsertDoc(pathStr, data)
+        upsertDoc(pathStr, value)
     }
+
+    /**
+     * Updates (or inserts) metadata into the metadata_ property of the doc state by invoking updatedDoc function
+     *
+     * @remarks
+     * This function is typically passed to an input wrapper component via the StoreContext.Provider value
+     * This function calls updateDoc, with the path to "data_" in dbDoc.
+     *
+     * @param pathStr A string path such as "foo.bar[2].biz" that represents a path into the doc state
+     * @param value The value that is to be updated/inserted
+     */
+    const upsertMetadata: UpsertMetadata = (pathStr, value) => {
+        pathStr = 'metadata_.' + pathStr
+        upsertDoc(pathStr, value)
+    }
+
     /**
      *
      * @param blob
@@ -326,6 +345,7 @@ export const StoreProvider: FC<StoreProviderProps> = ({
                 metadata: doc.metadata_,
                 upsertAttachment,
                 upsertData,
+                upsertMetadata,
             }}
         >
             {children}

--- a/src/components/store.tsx
+++ b/src/components/store.tsx
@@ -240,9 +240,7 @@ export const StoreProvider: FC<StoreProviderProps> = ({
                 return result
             })
                 .then(function (res) {
-                    if (pathStr.includes('metadata_')) {
-                        revisionRef.current = res.rev
-                    }
+                    revisionRef.current = res.rev
                 })
                 .catch(function (err: Error) {
                     console.error('upsert error:', err)

--- a/src/utilities/database_utils.tsx
+++ b/src/utilities/database_utils.tsx
@@ -24,6 +24,7 @@ export async function putNewDoc(
     // Store the new document if it does not exist
     return db.putIfNotExists({
         _id: docName,
+        data_: {},
         metadata_: {
             created_at: now,
             last_modified_at: now,


### PR DESCRIPTION
This fixes a couple of problems with the Store.
- Simplifies the Store state by eliminating the `data` and `metadata` state variables - they were not being updated properly anyway
- data and metadata are pulled directly from the `doc` state variable when passing to StoreConsumer
- Fixed a bug where the revision number was not being updated - this caused any change from our components to be reflected back from the database, leading to extra rendering
- No longer pass `upsertDoc()` to StoreConsumer - none of our components was using it anyway
- Added `upsertMetadata()` for future use.

I tested by changing input values and checking that those changes did not cause extra renders since it now correctly updates the revision value. By temporarily inserting console.log's, I verified that the revisions and rendering were working as expected.

However, there is a mystery:  For each update to the database, two identical on change messages are sent to our web app. Since the revision values are the same, it does no harm, but it is still a mystery.

These changes _may_ fix some of our issues around cursor jumping, but I did not check that.
