### PR TITLE
Project name alignment corrected in templates

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -58,6 +58,9 @@ h3 {
 h1 + h2 {
   text-align: center;
 }
+h1 + h3 {
+  text-align: center;
+}
 
 /* used in home.tsx */
 .flex-container {


### PR DESCRIPTION
Included CSS to center-align the 'h3' element when it appears following an 'h1' element. This styling isn't utilized elsewhere in the code. 
- Tested the templates and the reports for the proper display of the content.