### PR TITLE
Merge GH Pages Code into Main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# App Subdomain needed for running in GH pages
+# leave as blank (or '/') if running locally
+PUBLIC_ENV=/

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,19 @@
+name: Build App and Deploy
+
+on:
+  push:
+    branches: [ gh-pages-code ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build application and push
+        run: |
+          yarn install
+          echo ${GITHUB_REPOSITORY}
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          yarn deploy -u "github-actions-bot <support+actions@github.com>"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/404.html
+++ b/404.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ to serve the static files locally at `localhost:8080`. This
 serves `/build/index.html` for all routes (those without file extensions) and the 
 files within `./build/public/` for all other paths.
 
+## Deployment
+The QA webapp is hosted using github pages. When a commit is pushed to `main`, a github action is triggered which will build the widget and deploy the built artifact the branch `gh-pages`. This operation will overwrite the existing contents of the `gh-pages` branch. The target branch can be customized (see: https://github.com/tschaub/gh-pages).
+
+### A note about hosting on GH Pages
+Running the webapp on GH pages is different from a local environment in that the hosted app url includes a subdirectory (e.g. `Quality-Install-Tool` in the case of `pnnl.github.io/Quality-Install-Tool/`). To support this, the `PUBLIC_ENV` env var is to support proper app routing. If this repo is forked, `PUBLIC_ENV` will need to be set based on the name of the new repo that the app is hosted in. 
+
 ## linting and formatting
 The `yarn lint` command runs a linter to ensure all code is to the formatting standards for the repo before
 a pull request is made.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Single Page Apps for GitHub Pages</title>
+    <meta name="description" content="Lightweight solution for deploying single page apps with GitHub Pages.">
+
+    <style>
+      html { background-color: rgb(0, 120, 0); }
+    </style>
+
+    <!-- favicon -->
+    <link rel="icon" type=”image/svg+xml” href="/favicon/green-grid-144-168-192.svg">
+    <link rel="alternate icon" type="image/png" href="/favicon/green-grid-144-168-192-512x512.png">
+    <link rel="apple-touch-icon" href="/favicon/green-grid-144-168-192-180x180.png">
+    <link rel="manifest" href="/favicon/site.webmanifest">
+    <meta name="theme-color" content="#000000">
+
+    <!-- Start Single Page Apps for GitHub Pages -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
+    <!-- End Single Page Apps for GitHub Pages -->
+
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- single page app in bundle.js -->
+    <script src="/build/bundle.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -104,12 +104,16 @@
     "workbox-routing": "^6.4.2",
     "workbox-strategies": "^6.4.2",
     "workbox-streams": "^6.4.2",
-    "workbox-webpack-plugin": "^6.4.1"
+    "workbox-webpack-plugin": "^6.4.1",
+    "gh-pages": "^5.0.0",
+    "http-server": "^14.1.1"
   },
   "scripts": {
     "start": "HTTPS=true node scripts/start.js",
     "build": "TSC_COMPILE_ON_ERROR=true node scripts/build.js",
     "test": "node scripts/test.js",
+    "predeploy": "yarn build && cp ./404.html ./build",
+    "deploy": "gh-pages -d build",
     "lint": "NODE_ENV=development BABEL_ENV=development eslint 'src/**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "NODE_ENV=development BABEL_ENV=development eslint --fix 'src/**/*.{js,jsx,ts,tsx}'",
     "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,10 @@
 import 'bootstrap/dist/css/bootstrap.css'
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import {
+    createBrowserRouter,
+    Navigate,
+    RouterProvider,
+    useRouteError,
+} from 'react-router-dom'
 import './App.css'
 import TemplateEditor from './components/editor'
 import WorkFlowView from './components/workflow_view'
@@ -100,7 +105,7 @@ const routes = [
     )
 
 // React Router
-const router = createBrowserRouter(routes)
+const router = createBrowserRouter(routes, { basename: process.env.PUBLIC_URL })
 
 function App(): any {
     return <RouterProvider router={router} />

--- a/src/components/figure_wrapper.tsx
+++ b/src/components/figure_wrapper.tsx
@@ -15,9 +15,10 @@ interface FigureWrapperProps {
  * @param src The image source passed to an underlying img tag
  */
 const FigureWrapper: FC<FigureWrapperProps> = ({ children, src }) => {
+    const formattedUrl = process.env.PUBLIC_URL + src
     return (
         <Figure>
-            <FigureImage src={src} />
+            <FigureImage src={formattedUrl} />
             <FigureCaption>{children}</FigureCaption>
         </Figure>
     )

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -6,6 +6,7 @@ import PouchDB from 'pouchdb'
 import { TfiPlus, TfiTrash } from 'react-icons/tfi'
 import StringInputModal from './string_input_modal'
 import dbName from './db_details'
+import { useNavigate } from 'react-router-dom'
 import { retrieveProjects } from '../utilities/database_utils'
 
 /**
@@ -14,6 +15,8 @@ import { retrieveProjects } from '../utilities/database_utils'
  * @returns ListGroup component displaying the projects created
  */
 const Home: FC = () => {
+    const path = window.location.href.split('?')[1]
+    const navigate = useNavigate()
     const db = new PouchDB(dbName)
 
     const [sortedProjectList, setSortedProjectList] = useState<any[]>([])
@@ -43,6 +46,9 @@ const Home: FC = () => {
 
     useEffect(() => {
         retrieveProjectInfo()
+        if (path) {
+            navigate(path)
+        }
     }, [])
 
     const validateInput = [


### PR DESCRIPTION
This branch contains some modifications that are necessary to run the QIT tool from GH pages. I'd like to merge these into `main` so that they don't get overwritten if these files are updated on `main` and then merged into this branch for deployment to GH pages. 

The main change in this PR is use of the useNavigate hook for navigation and dependencies being added for deployment to GH pages. 