### PR TITLE
Resolve TS compiler errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "scripts": {
     "start": "HTTPS=true node scripts/start.js",
-    "build": "TSC_COMPILE_ON_ERROR=true node scripts/build.js",
+    "build": "node scripts/build.js",
     "test": "node scripts/test.js",
     "lint": "NODE_ENV=development BABEL_ENV=development eslint 'src/**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "NODE_ENV=development BABEL_ENV=development eslint --fix 'src/**/*.{js,jsx,ts,tsx}'",

--- a/public/print.css
+++ b/public/print.css
@@ -55,7 +55,19 @@ h3 {
   font-size: 1rem;
   break-after: avoid-page;
 }
+/* used in all templates - for report title */
 h1 + h2 {
+  text-align: center;
+}
+
+/* used in mdx_project_details_view.tsx */
+h1 + h3 {
+  text-align: center;
+}
+
+/* used in workflows_view.tsx, mdx_template_view.tsx, job_view.tsx  */
+.address
+{
   text-align: center;
 }
 
@@ -92,11 +104,6 @@ h1 + h2 {
   margin-bottom: 10px;
 }
 
-/* headding */
-h3 {
-  font-size: 1.3rem; 
-  text-align: center;
-}
 
 .string-input-modal{
   .error{
@@ -214,4 +221,9 @@ h3 {
   color: red;
   padding-left: .75rem;
   font-size: 0.9rem;
+}
+
+/* used in home.tsx  */
+.padding {
+  padding: 5px 10px 5px 10px;  /* top right bottom left*/
 }

--- a/src/components/file_input_wrapper.tsx
+++ b/src/components/file_input_wrapper.tsx
@@ -24,15 +24,19 @@ const FileInputWrapper: FC<FileInputWrapperProps> = ({
         <StoreContext.Consumer>
             {({ attachments, jobId, upsertAttachment }) => {
                 //  JobId for installation level updates
-                let id_ref = jobId != '' ? jobId + '.' + id : id
+                const id_ref = `${jobId === '' ? '' : `${jobId}.`}${id}`
+                const attachment = Object.getOwnPropertyDescriptor(
+                    attachments,
+                    id_ref,
+                )?.value
                 const upsertFile = (img_file: Blob, fileName: string) => {
                     upsertAttachment(img_file, id_ref, fileName)
                 }
                 return (
                     <FileInput
                         label={label}
-                        fileMetadata={attachments[id_ref]?.metadata}
-                        file={attachments[id_ref]?.blob}
+                        fileMetadata={attachment?.metadata}
+                        file={attachment?.blob}
                         upsertFile={upsertFile}
                     >
                         {children}

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -132,7 +132,7 @@ const Home: FC = () => {
     const handleRenameProject = async (input: string, docId: string) => {
         try {
             if (input !== null) {
-                await db.upsert(docId, function (doc) {
+                await db.upsert(docId, function (doc: any) {
                     doc.metadata_.project_name = input
                     return doc
                 })

--- a/src/components/jobs_view.tsx
+++ b/src/components/jobs_view.tsx
@@ -122,7 +122,7 @@ const JobList: React.FC<JobListProps> = ({ workflowName, docId }) => {
     const confirmDeleteJob = async () => {
         try {
             const projectDoc = await db.get(docId)
-            await db.upsert(docId, function (projectDoc) {
+            await db.upsert(docId, function (projectDoc: any) {
                 let del_index = -1
                 projectDoc.installations_.map(
                     async (key: any, workflow_name: string, value: number) => {
@@ -166,7 +166,7 @@ const JobList: React.FC<JobListProps> = ({ workflowName, docId }) => {
             if (input !== null) {
                 const projectDoc = await db.get(docId)
 
-                await db.upsert(docId, function (projectDoc) {
+                await db.upsert(docId, function (projectDoc: any) {
                     projectDoc.installations_.map(
                         async (key: any, workflow_name: string) => {
                             if (
@@ -232,7 +232,7 @@ const JobList: React.FC<JobListProps> = ({ workflowName, docId }) => {
           </Dropdown.Item>
           <Dropdown.Item onClick={event => {sortByEditTime(jobsList)}}>
             Sort By Edit Date
-          </Dropdown.Item> 
+          </Dropdown.Item>
         </Dropdown.Menu>
       </Dropdown> */}
 

--- a/src/components/mdx_project_details_view.tsx
+++ b/src/components/mdx_project_details_view.tsx
@@ -32,6 +32,7 @@ const MdxProjectView: FC<MdxProjectViewProps> = ({ project }) => {
             <h3>{project?.metadata_?.project_name}</h3>
             <MdxWrapper
                 Component={DOEProjectDetailsTemplate}
+                JobId=""
                 Project={project}
             />
         </StoreProvider>

--- a/src/components/mdx_wrapper.tsx
+++ b/src/components/mdx_wrapper.tsx
@@ -22,7 +22,7 @@ import RadioWrapper from './radio_wrapper'
 import PageBreak from './page_break'
 import ProjectInfoInputs from '../templates/reusable/project_info_inputs.mdx'
 import ProjectInfoReport from '../templates/reusable/project_info_report.mdx'
-import PrintSectionWrapper from './print_section wrapper'
+import PrintSectionWrapper from './print_section_wrapper'
 import FileInputWrapper from './file_input_wrapper'
 import PDFRendererWrapper from './pdf_renderer_wrapper'
 

--- a/src/components/pdf_renderer_wrapper.tsx
+++ b/src/components/pdf_renderer_wrapper.tsx
@@ -26,13 +26,17 @@ const PDFRenderedWrapper: FC<PDFRenderedWrapperProps> = ({
         <StoreContext.Consumer>
             {({ attachments, jobId, upsertAttachment }) => {
                 //  JobId for installation level updates
-                let id_ref = jobId != '' ? jobId + '.' + id : id
+                const id_ref = `${jobId === '' ? '' : `${jobId}.`}${id}`
+                const attachment = Object.getOwnPropertyDescriptor(
+                    attachments,
+                    id_ref,
+                )?.value
                 return (
                     <PDFRenderer
                         children={children}
                         label={label}
-                        fileMetadata={attachments[id_ref]?.metadata}
-                        file={attachments[id_ref]?.blob}
+                        fileMetadata={attachment?.metadata}
+                        file={attachment?.blob}
                     />
                 )
             }}

--- a/src/components/photo_input_wrapper.tsx
+++ b/src/components/photo_input_wrapper.tsx
@@ -35,8 +35,11 @@ const PhotoInputWrapper: FC<PhotoInputWrapperProps> = ({
         <StoreContext.Consumer>
             {({ attachments, upsertAttachment, jobId }) => {
                 //  JobId for installation level updates
-                let id_ref = jobId == '' ? id : jobId + '.' + id
-
+                const id_ref = `${jobId === '' ? '' : `${jobId}.`}${id}`
+                const attachment = Object.getOwnPropertyDescriptor(
+                    attachments,
+                    id_ref,
+                )?.value
                 const upsertPhoto = (img_file: Blob) => {
                     // Reduce the image size as needed
                     ImageBlobReduce()
@@ -48,11 +51,8 @@ const PhotoInputWrapper: FC<PhotoInputWrapperProps> = ({
                 return (
                     <PhotoInput
                         label={label}
-                        metadata={
-                            attachments[id_ref]
-                                ?.metadata as unknown as PhotoMetadata
-                        }
-                        photo={attachments[id_ref]?.blob}
+                        metadata={attachment?.metadata as PhotoMetadata}
+                        photo={attachment?.blob}
                         upsertPhoto={upsertPhoto}
                         uploadable={uploadable}
                     >

--- a/src/components/photo_wrapper.tsx
+++ b/src/components/photo_wrapper.tsx
@@ -34,20 +34,22 @@ const PhotoWrapper: FC<PhotoWrapperProps> = ({
         <StoreContext.Consumer>
             {({ attachments, data, jobId }) => {
                 //  JobId for installation level updates
-                let id_ref =
-                    jobId != '' && id != 'building_number_photo'
-                        ? jobId + '.' + id
-                        : id
+                const id_ref = `${
+                    jobId === '' || jobId === 'building_number_photo'
+                        ? ''
+                        : `${jobId}.`
+                }${id}`
+                const attachment = Object.getOwnPropertyDescriptor(
+                    attachments,
+                    id_ref,
+                )?.value
                 return (
                     <Photo
                         description={children}
                         id={id_ref}
                         label={label}
-                        metadata={
-                            attachments[id_ref]
-                                ?.metadata as unknown as PhotoMetadata
-                        }
-                        photo={attachments[id_ref]?.blob}
+                        metadata={attachment?.metadata as PhotoMetadata}
+                        photo={attachment?.blob}
                         required={required}
                     />
                 )

--- a/src/components/print_section_wrapper.tsx
+++ b/src/components/print_section_wrapper.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 
+import type Metadata from '../types/metadata.type'
 import { StoreContext } from './store'
 import PrintSection from './print_section'
 
@@ -27,8 +28,14 @@ const PrintSectionWrapper: FC<PrintSectionWrapperProps> = ({
                     <PrintSection
                         children={children}
                         label={label}
-                        project_name={metadata.project_name}
-                        workflow_name={metadata.workflow_name}
+                        project_name={
+                            (metadata as Metadata | Record<string, string>)
+                                .project_name
+                        }
+                        workflow_name={
+                            (metadata as Metadata | Record<string, string>)
+                                .workflow_name
+                        }
                     />
                 )
             }}

--- a/src/components/store.tsx
+++ b/src/components/store.tsx
@@ -12,7 +12,7 @@ import { isEmpty, isObject, toNumber, toPath } from 'lodash'
 import type JSONValue from '../types/json_value.type'
 import { getMetadataFromCurrentGPSLocation } from '../utilities/photo_utils'
 import type Attachment from '../types/attachment.type'
-import type { Objectish, NonEmptyArray } from '../types/misc_types.type'
+import type { NonEmptyArray } from '../types/misc_types.type'
 import type Metadata from '../types/metadata.type'
 import {
     putNewDoc,
@@ -85,9 +85,9 @@ export const StoreProvider: FC<StoreProviderProps> = ({
     )
     const [db, setDB] = useState<PouchDB.Database>()
     // The doc state could be anything that is JSON-compatible
-    const [doc, setDoc] = useState<Objectish>({})
+    const [doc, setDoc] = useState<any>({})
 
-    const [installationDoc, setInstallationDoc] = useState<Objectish>({})
+    const [installationDoc, setInstallationDoc] = useState<any>({})
 
     const isInstallationUpdate = pathIndex >= 0
 
@@ -418,12 +418,12 @@ export const StoreProvider: FC<StoreProviderProps> = ({
  * @returns A shallow copy of recipient that additionally has the value at path set to target
  */
 export function immutableUpsert(
-    recipient: Objectish,
+    recipient: any,
     path: NonEmptyArray<string>,
     target: any,
-): Objectish {
+): any {
     const [propName, ...newPath] = path
-    const newRecipient = isObject(recipient)
+    const newRecipient: any = isObject(recipient)
         ? Array.isArray(recipient)
             ? [...recipient]
             : ({ ...recipient } satisfies Record<string, any>)

--- a/src/templates/projects_config.ts
+++ b/src/templates/projects_config.ts
@@ -2,7 +2,7 @@ import PouchDB from 'pouchdb'
 import dbName from '../components/db_details'
 
 /* Retrieves the updated project doc from the pouch DB
-- Used in the App.tsx to populate the routes accordingly when new project is created 
+- Used in the App.tsx to populate the routes accordingly when new project is created
 */
 const db = new PouchDB(dbName)
 const result = await db.allDocs({ include_docs: true })

--- a/src/types/misc_types.type.ts
+++ b/src/types/misc_types.type.ts
@@ -2,7 +2,7 @@
 
 import JSONValue from './json_value.type'
 
-export type Object = AnyObject | AnyArray | JSONValue
+export type Objectish = AnyObject | AnyArray | JSONValue
 export type AnyObject = { [key: string]: any }
 export type AnyArray = Array<any>
 export type NonEmptyArray<T> = [T, ...Array<T>]

--- a/src/utilities/database_utils.tsx
+++ b/src/utilities/database_utils.tsx
@@ -93,7 +93,7 @@ export async function putNewWorkFlow(
         throw new Error('Database info should never be null')
     }
 
-    const projectDoc = await db.get(docId)
+    const projectDoc: any = await db.get(docId)
 
     const doc_name = docName
     const workflow_name = workflowName
@@ -183,9 +183,9 @@ export async function retrieveJobs_db(
     workflowName: string,
 ): Promise<any> {
     try {
-        const projectDoc = await db.get(docId)
+        const projectDoc: any = await db.get(docId)
         let jobList: any[] = []
-        projectDoc.installations_.map((key, value) => {
+        projectDoc.installations_.map((key: any, value: any) => {
             if (key.metadata_.workflow_name == workflowName) {
                 jobList.push(key)
             }
@@ -209,7 +209,7 @@ export async function retrieveProjectSummary(
     workflowName: string,
 ): Promise<any> {
     try {
-        const doc = await db.get(docId)
+        const doc: any = await db.get(docId)
 
         if (doc) {
             const project_name = doc.metadata_?.project_name

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
Resolves #15, resolves #128.

For the "wrapper" components, the error was that the `attachments` object did not accept keys of the `string` type, but the value of the `id_ref` variable was of the `string` type. I resolved these errors by replacing the `[]` index operator with the `Object.getOwnPropertyDescriptor` function.

For the error with the top-level `await` statement in the `src/templates/projects_config.ts` file, I bumped the compiler target to `es2017`.

Finally, the remaining errors were all variables with the implicit `any` type, which I made explicit. These could be improved by typing the output of the `PouchDB.Database<T>.get` function.