### PR TITLE
Changes to enable offline capability

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -704,7 +704,7 @@ module.exports = async function (webpackEnv) {
           // Bump up the default maximum size (2mb) that's precached,
           // to make lazy-loading failure scenarios less likely.
           // See https://github.com/cra-template/pwa/issues/13#issuecomment-722667270
-          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+          maximumFileSizeToCacheInBytes: 20 * 1024 * 1024
         }),
       // TypeScript type checking
       useTypeScript &&

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "workbox-webpack-plugin": "^6.4.1"
   },
   "scripts": {
-    "start": "HTTPS=true node scripts/start.js",
+    "start": "node scripts/start.js",
     "build": "TSC_COMPILE_ON_ERROR=true node scripts/build.js",
     "test": "node scripts/test.js",
     "lint": "NODE_ENV=development BABEL_ENV=development eslint 'src/**/*.{js,jsx,ts,tsx}'",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,8 @@ root.render(
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://cra.link/PWA
-serviceWorkerRegistration.unregister()
+// Register the service worker
+serviceWorkerRegistration.register()
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
Minor updates were made to address warnings during the local build. 
I have tested the offline functionality by setting the environment variable to 'development' in both webpack.config.js and serviceWorkerRegistration.js.



