### PR TITLE
Building-photo-not-populated-in-the-report

### DIFF
--- a/src/templates/ira_doe_workflow_limited_assessment.mdx
+++ b/src/templates/ira_doe_workflow_limited_assessment.mdx
@@ -195,7 +195,7 @@
   {props.project.data_.installer?.name ? <span>&nbsp;&nbsp;&nbsp;&nbsp;{props.project.data_.installer?.name}</span> : null} {props.project.data_.installer?.name ? <br/>: null}
   {props.project.data_.installer?.company_name ? <span>&nbsp;&nbsp;&nbsp;&nbsp;{props.project.data_.installer?.company_name}</span> : null}{props.project.data_.installer?.company_name ? <br/>: null}
 
-  **Assessment Date:**  <DateStr date={props.data.install_date}/> 
+  **Assessment Date:**  <DateStr date={props.data.assessment_date}/> 
 
   **Assessment For:** {props.data.assessment_for}
 

--- a/src/templates/reusable/project_info_report.mdx
+++ b/src/templates/reusable/project_info_report.mdx
@@ -28,6 +28,6 @@
  **Installation Address:** <LabelValue path="location.street_address" suffix=", "/><LabelValue path="location.city" suffix=", " /><LabelValue path="location.state" suffix=", " /> <LabelValue path="location.zip_code" />
 </ShowOrHide>
 
-<Photo id="building_number_photo" label="Building Number" project={props.project} required>
+<Photo id="building_number_photo" label="Building Number" parent={props.project} required>
       A photo of the building showing the building number.
 </Photo>


### PR DESCRIPTION
The property to denote the project was named wrongly in Building Photo tag. This is corrected now.