### PR TITLE
Limited assessment Issue 

### DIFF
--- a/src/utilities/path_utils.ts
+++ b/src/utilities/path_utils.ts
@@ -32,9 +32,11 @@ function _immutableUpsert<T extends Array<unknown> | Record<string, unknown>>(
                     ? value
                     : _immutableUpsert(
                           nextPath as NonEmptyArray<string>,
-                          sender[propName] as
-                              | Array<unknown>
-                              | Record<string, unknown>,
+                          sender[propName] !== undefined
+                              ? (sender[propName] as
+                                    | Array<unknown>
+                                    | Record<string, unknown>)
+                              : {},
                           value,
                       ),
         }


### PR DESCRIPTION
Issue: The issue arises because the `_immutableUpsert` function is trying to access an array index (0) on a property (heating_systems) that is either undefined or not initialized as an array. This leads to the error:
TypeError: Cannot read properties of undefined (reading '0').

Fix: Added a default value ({}) for undefined properties to ensure the recursive call always has a valid structure to work with.

Recursive call and the fix tested
First call:
path = ['heating_systems', '0', 'fuel_and_system_type']
sender = { heating_systems: undefined }
propName = 'heating_systems' 
if sender['heating_systems'] is undefined, it is initialized as {}.

Recursive call 1:
path = ['0', 'fuel_and_system_type']
sender = {}
propName = '0'
sender['0'] is undefined, it is initialized as {}.

Recursive call 2:  // This time it is the array field, no change in the code in this part
path = ['fuel_and_system_type']
sender = {}
propName = 'fuel_and_system_type'
sender['fuel_and_system_type'] is set to 'ELECTRIC_HEAT_PUMP'  

This also fixed the issue#282