### PR TITLE
Update to photo attachment migration to exclude file attachment

### DIFF
--- a/src/migrations/1_photo_attachment_id_suffixes.ts
+++ b/src/migrations/1_photo_attachment_id_suffixes.ts
@@ -101,8 +101,8 @@ export function transformPhotoAttachmentIdSuffixes<Model>(
         _attachments: Object.fromEntries(
             Object.entries(doc._attachments ?? {}).map(
                 ([attachmentId, attachment]) => {
-                    const newAttachmentId = !['manual_j_file'].includes(
-                        attachmentId,
+                    const newAttachmentId = attachmentId.match(
+                        RE_PHOTO_ATTACHMENT_ID,
                     )
                         ? targetPhotoAttachmentIdBySourcePhotoAttachmentId[
                               attachmentId

--- a/src/migrations/1_photo_attachment_id_suffixes.ts
+++ b/src/migrations/1_photo_attachment_id_suffixes.ts
@@ -101,11 +101,13 @@ export function transformPhotoAttachmentIdSuffixes<Model>(
         _attachments: Object.fromEntries(
             Object.entries(doc._attachments ?? {}).map(
                 ([attachmentId, attachment]) => {
-                    const newAttachmentId =
-                        targetPhotoAttachmentIdBySourcePhotoAttachmentId[
-                            attachmentId
-                        ]
-
+                    const newAttachmentId = !['manual_j_file'].includes(
+                        attachmentId,
+                    )
+                        ? targetPhotoAttachmentIdBySourcePhotoAttachmentId[
+                              attachmentId
+                          ]
+                        : attachmentId
                     if (newAttachmentId === undefined) {
                         throw new Error(
                             `Replacement attachment ID not found: ${attachmentId}`,


### PR DESCRIPTION
File name 'manual_j_file' is explicitly checked during the migrations, as thats the only file attachment. 

